### PR TITLE
Remove about link from header

### DIFF
--- a/src/component/header/index.tsx
+++ b/src/component/header/index.tsx
@@ -42,7 +42,6 @@ const Header = () => {
   return (
     <div className={style.header_container}>
          <Link href='/'><p>M&B</p></Link>
-         <Link href='/about'><p>About</p></Link>
         <p className={style.header_text}>All Your Fashion Needs</p>
         <div className={style.icon_wrap} >
         <p className={style.search_icon}>


### PR DESCRIPTION
Remove the 'About' link from the header component as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ee63f1b-e7d0-4640-b39a-ea8b8e29ad10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ee63f1b-e7d0-4640-b39a-ea8b8e29ad10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

